### PR TITLE
fix: typeScript lint does not apply on examples folder correctly issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
      * Following for typescript .ts only
      */
     {
-      files: ['{src, examples}/**/*.ts'],
+      files: ['{src,examples}/**/*.ts'],
       extends: [
         'airbnb-typescript/base',
         'plugin:prettier/recommended',


### PR DESCRIPTION
[Issue]
In examples folder, import TypeScript type into a file will cause a lint error, such as `error  'UnixTimestamp' is defined but never used  no-unused-vars`

[Root cause]
TypeScript lint rule does not apply correctly due to the override path failing.
`files: ['{src, examples}/**/*.ts']` will let eslint try to lint folder ` examples` (With leading blank) instead of `examples`

[Solution]
Correct `files: ['{src, examples}/**/*.ts']` to `files: ['{src,examples}/**/*.ts']`